### PR TITLE
Apply bloom_product shortcode to carousel

### DIFF
--- a/wp-content/themes/twentytwentyfive/front-page.php
+++ b/wp-content/themes/twentytwentyfive/front-page.php
@@ -45,28 +45,9 @@ function bloom_featured_products_html() {
                     </svg>
                 </button>
                 <div class="row featured-product-slider">
-                <?php while ( $query->have_posts() ) : $query->the_post(); global $product; ?>
+                <?php while ( $query->have_posts() ) : $query->the_post(); ?>
                     <div class="col-12">
-                        <div class="product-card">
-                            <figure>
-                                <a href="<?php the_permalink(); ?>">
-                                    <?php echo $product->get_image(); ?>
-                                </a>
-                                <ul class="unstyled action-list">
-                                    <li><a href="javascript:;" class="icon wishlist-icon"><i class="fa-light fa-heart"></i></a></li>
-                                    <li><a href="<?php the_permalink(); ?>" class="icon"><i class="fa-light fa-eye"></i></a></li>
-                                </ul>
-                            </figure>
-                            <div class="text-block">
-                                <a href="<?php the_permalink(); ?>" class="h4 mb-16"><?php the_title(); ?></a>
-                                <div class="price mb-32">
-                                    <?php echo $product->get_price_html(); ?>
-                                </div>
-                                <div class="action-block">
-                                    <?php woocommerce_template_loop_add_to_cart(); ?>
-                                </div>
-                            </div>
-                        </div>
+                        <?php echo do_shortcode( '[bloom_product id="' . get_the_ID() . '"]' ); ?>
                     </div>
                 <?php endwhile; ?>
                 </div>


### PR DESCRIPTION
## Summary
- use the `bloom_product` shortcode in the home page featured products carousel

## Testing
- `php -l wp-content/themes/twentytwentyfive/front-page.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847cb226914832a9e5b4c7ba0f35728