### PR TITLE
Disable WooCommerce block template

### DIFF
--- a/wp-content/themes/twentytwenty-child/functions.php
+++ b/wp-content/themes/twentytwenty-child/functions.php
@@ -5,4 +5,31 @@ function twentytwenty_child_enqueue_styles() {
     wp_enqueue_style( 'twentytwenty-child-style', get_stylesheet_uri(), array( 'twentytwenty-style', 'bloom-style' ), wp_get_theme()->get('Version') );
 }
 add_action( 'wp_enqueue_scripts', 'twentytwenty_child_enqueue_styles' );
+
+/**
+ * Disable WooCommerce block templates for the single product page.
+ *
+ * Returning false for the "single-product" template name forces
+ * WooCommerce to load the PHP template from the theme instead of the
+ * block template provided by the plugin.
+ *
+ * @param bool   $has_template  Whether a block template exists.
+ * @param string $template_name Name of the template being checked.
+ * @return bool Modified result.
+ */
+function twentytwenty_child_disable_single_product_block_template( $has_template, $template_name ) {
+    if ( 'single-product' === $template_name ) {
+        $theme_template  = get_stylesheet_directory() . '/templates/single-product.html';
+        $legacy_template = get_stylesheet_directory() . '/block-templates/single-product.html';
+
+        if ( file_exists( $theme_template ) || file_exists( $legacy_template ) ) {
+            return $has_template;
+        }
+
+        return false;
+    }
+
+    return $has_template;
+}
+add_filter( 'woocommerce_has_block_template', 'twentytwenty_child_disable_single_product_block_template', 10, 2 );
 ?>

--- a/wp-content/themes/twentytwenty-child/templates/single-product.html
+++ b/wp-content/themes/twentytwenty-child/templates/single-product.html
@@ -1,0 +1,37 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"}} -->
+<main class="wp-block-group">
+    <!-- wp:woocommerce/breadcrumbs /-->
+    <!-- wp:woocommerce/store-notices /-->
+    <section class="py-80">
+        <div class="container-fluid">
+            <div class="row justify-content-center">
+                <div class="col-xxl-8 col-xl-10 col-lg-11">
+                    <div class="product-detail pb-80">
+                        <div class="row row-gap-4">
+                            <div class="col-md-6">
+                                <!-- wp:woocommerce/product-image-gallery /-->
+                            </div>
+                            <div class="col-md-6">
+                                <div class="product-detail-content">
+                                    <!-- wp:post-title {"level":1,"__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->
+                                    <!-- wp:woocommerce/product-rating {"isDescendentOfSingleProductTemplate":true} /-->
+                                    <!-- wp:woocommerce/product-price {"isDescendentOfSingleProductTemplate":true,"fontSize":"large"} /-->
+                                    <!-- wp:post-excerpt {"__woocommerceNamespace":"woocommerce/product-query/product-summary","excerptLength":100} /-->
+                                    <!-- wp:woocommerce/add-to-cart-form /-->
+                                    <!-- wp:woocommerce/product-meta {"layout":{"type":"flex","flexWrap":"nowrap"}} /-->
+                                </div>
+                            </div>
+                        </div>
+                        <!-- wp:woocommerce/product-details {"className":"is-style-minimal"} /-->
+                        <!-- wp:pattern {"slug":"woocommerce-blocks/related-products"} /-->
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
## Summary
- disable WooCommerce block template for single product page when no theme override exists
- add a custom `templates/single-product.html` block template

## Testing
- ❌ `php -l wp-content/themes/twentytwenty-child/functions.php` (failed to run because `php` was not found)
- ❌ `php -l wp-content/themes/twentytwenty-child/templates/single-product.html` (failed to run because `php` was not found)


------
https://chatgpt.com/codex/tasks/task_e_6849301ee31c832a88567cfd6fb61eb9