### PR TITLE
Add Bloom style to WooCommerce product template

### DIFF
--- a/wp-content/themes/twentytwenty-child/functions.php
+++ b/wp-content/themes/twentytwenty-child/functions.php
@@ -1,13 +1,19 @@
 <?php
 function twentytwenty_child_enqueue_styles() {
     wp_enqueue_style( 'twentytwenty-style', get_template_directory_uri() . '/style.css' );
-    wp_enqueue_style( 'bloom-style', get_theme_root_uri() . '/bloom-theme/assets/css/app.css', array(), null );
+    $bloom_base = get_stylesheet_directory_uri() . '/bloom/assets/css/';
+    wp_enqueue_style( 'bloom-fontawesome', $bloom_base . 'vendor/fontawsome.css', array(), null );
+    wp_enqueue_style( 'bloom-bootstrap', $bloom_base . 'vendor/bootstrap.min.css', array(), null );
+    wp_enqueue_style( 'bloom-magnific', $bloom_base . 'vendor/jquery.magnific-popup.css', array(), null );
+    wp_enqueue_style( 'bloom-animate', $bloom_base . 'vendor/animate.min.css', array(), null );
+    wp_enqueue_style( 'bloom-slick', $bloom_base . 'vendor/slick.css', array(), null );
+    wp_enqueue_style( 'bloom-style', $bloom_base . 'app.css', array( 'bloom-fontawesome', 'bloom-bootstrap', 'bloom-magnific', 'bloom-animate', 'bloom-slick' ), null );
     wp_enqueue_style( 'twentytwenty-child-style', get_stylesheet_uri(), array( 'twentytwenty-style', 'bloom-style' ), wp_get_theme()->get('Version') );
 }
 add_action( 'wp_enqueue_scripts', 'twentytwenty_child_enqueue_styles' );
 
 function twentytwenty_child_enqueue_scripts() {
-    $base = get_theme_root_uri() . '/bloom-theme/assets/js/';
+    $base = get_stylesheet_directory_uri() . '/bloom/assets/js/';
     wp_enqueue_script( 'bloom-bootstrap', $base . 'vendor/bootstrap.min.js', array( 'jquery' ), null, true );
     wp_enqueue_script( 'bloom-appear', $base . 'vendor/jquery-appear.js', array( 'jquery' ), null, true );
     wp_enqueue_script( 'bloom-nice-select', $base . 'vendor/jquery.nice-select.min.js', array( 'jquery' ), null, true );

--- a/wp-content/themes/twentytwenty-child/functions.php
+++ b/wp-content/themes/twentytwenty-child/functions.php
@@ -6,6 +6,19 @@ function twentytwenty_child_enqueue_styles() {
 }
 add_action( 'wp_enqueue_scripts', 'twentytwenty_child_enqueue_styles' );
 
+function twentytwenty_child_enqueue_scripts() {
+    $base = get_theme_root_uri() . '/bloom-theme/assets/js/';
+    wp_enqueue_script( 'bloom-bootstrap', $base . 'vendor/bootstrap.min.js', array( 'jquery' ), null, true );
+    wp_enqueue_script( 'bloom-appear', $base . 'vendor/jquery-appear.js', array( 'jquery' ), null, true );
+    wp_enqueue_script( 'bloom-nice-select', $base . 'vendor/jquery.nice-select.min.js', array( 'jquery' ), null, true );
+    wp_enqueue_script( 'bloom-slick', $base . 'vendor/slick.min.js', array( 'jquery' ), null, true );
+    wp_enqueue_script( 'bloom-wow', $base . 'vendor/wow.js', array( 'jquery' ), null, true );
+    wp_enqueue_script( 'bloom-range', $base . 'vendor/ion.rangeSlider.js', array( 'jquery' ), null, true );
+    wp_enqueue_script( 'bloom-magnific', $base . 'vendor/jquery.magnific-popup.min.js', array( 'jquery' ), null, true );
+    wp_enqueue_script( 'bloom-app', $base . 'app.js', array( 'jquery', 'bloom-slick' ), null, true );
+}
+add_action( 'wp_enqueue_scripts', 'twentytwenty_child_enqueue_scripts' );
+
 /**
  * Disable WooCommerce block templates for the single product page.
  *

--- a/wp-content/themes/twentytwenty-child/woocommerce/content-single-product.php
+++ b/wp-content/themes/twentytwenty-child/woocommerce/content-single-product.php
@@ -18,17 +18,111 @@ if ( post_password_required() ) {
                     <div class="product-detail pb-80">
                         <div class="row row-gap-4">
                             <div class="col-md-6">
-                                <div class="preview">
-                                    <?php
-                                    do_action( 'woocommerce_before_single_product_summary' );
-                                    ?>
+                                <div class="row align-items-center row-gap-3">
+                                    <div class="list">
+                                        <button class="slider-btn prev-btn" data-slide="preview-slider-nav">
+                                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 16" fill="none">
+                                                <path d="M0.857543 12.1506C1.14152 12.4346 1.60203 12.4347 1.88605 12.1506L8.64436 5.39213L15.403 12.1506C15.687 12.4346 16.1475 12.4347 16.4315 12.1506C16.7155 11.8666 16.7155 11.4061 16.4315 11.1221L9.15859 3.84935C9.0222 3.71296 8.83723 3.63635 8.64436 3.63635C8.45148 3.63635 8.26647 3.71301 8.13013 3.84939L0.857592 11.1221C0.573519 11.4061 0.573519 11.8666 0.857543 12.1506Z"/>
+                                            </svg>
+                                        </button>
+                                        <div class="preview-slider-nav mt-3">
+                                            <?php
+                                            $attachment_ids = $product->get_gallery_image_ids();
+                                            $main_id        = $product->get_image_id();
+                                            if ( $main_id ) {
+                                                array_unshift( $attachment_ids, $main_id );
+                                            }
+                                            foreach ( $attachment_ids as $id ) :
+                                                $img = wp_get_attachment_image( $id, 'woocommerce_thumbnail' );
+                                                ?>
+                                                <div class="detail-img-block">
+                                                    <?php echo $img; ?>
+                                                </div>
+                                            <?php endforeach; ?>
+                                        </div>
+                                        <button class="slider-btn next-btn" data-slide="preview-slider-nav">
+                                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 16" fill="none">
+                                                <path d="M16.4315 3.84935C16.1475 3.56537 15.687 3.56532 15.403 3.84939L8.6447 10.6078L1.88606 3.84935C1.60208 3.56537 1.14157 3.56532 0.857549 3.84939C0.573525 4.13342 0.573525 4.59388 0.857549 4.8779L8.13047 12.1506C8.26686 12.287 8.45183 12.3636 8.6447 12.3636C8.83757 12.3636 9.02259 12.287 9.15893 12.1506L16.4315 4.87786C16.7155 4.59388 16.7155 4.13337 16.4315 3.84935Z"/>
+                                            </svg>
+                                        </button>
+                                    </div>
+                                    <div class="preview">
+                                        <div class="preview-slider">
+                                            <?php
+                                            foreach ( $attachment_ids as $id ) :
+                                                $img = wp_get_attachment_image( $id, 'large' );
+                                                ?>
+                                                <div class="detail-img-block">
+                                                    <?php echo $img; ?>
+                                                </div>
+                                            <?php endforeach; ?>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                             <div class="col-md-6">
                                 <div class="product-detail-content">
-                                    <?php
-                                    do_action( 'woocommerce_single_product_summary' );
-                                    ?>
+                                    <div class="d-flex align-items-center column-gap-2 row-gap-3 mb-16">
+                                        <h4><?php the_title(); ?></h4>
+                                        <?php if ( $product->is_in_stock() ) : ?>
+                                            <p class="green-tag"><?php esc_html_e( 'In Stock', 'twentytwenty-child' ); ?></p>
+                                        <?php endif; ?>
+                                    </div>
+                                    <ul class="unstyled mb-24 pro-rel">
+                                        <li class="d-flex align-items-center">
+                                            <span class="rating-stars me-1"><?php echo wc_get_rating_html( $product->get_average_rating() ); ?></span>
+                                            <span class="text-decoration-underline"><?php echo esc_html( $product->get_review_count() ); ?> <?php esc_html_e( 'Reviews', 'twentytwenty-child' ); ?></span>
+                                        </li>
+                                        <?php if ( wc_product_sku_enabled() && $product->get_sku() ) : ?>
+                                            <li>
+                                                <span class="bold-text accent-dark me-1"><?php esc_html_e( 'SKU:', 'twentytwenty-child' ); ?></span><span><?php echo esc_html( $product->get_sku() ); ?></span>
+                                            </li>
+                                        <?php endif; ?>
+                                    </ul>
+                                    <div class="d-flex align-items-center column-gap-2 row-gap-3 mb-24">
+                                        <div class="price">
+                                            <?php if ( $product->is_on_sale() ) : ?>
+                                                <del class="h6 dark-gray"><?php echo wc_price( $product->get_regular_price() ); ?></del>
+                                            <?php endif; ?>
+                                            <h3><?php echo wc_price( $product->get_price() ); ?></h3>
+                                        </div>
+                                        <?php
+                                        if ( $product->is_on_sale() ) {
+                                            $regular = (float) $product->get_regular_price();
+                                            $sale    = (float) $product->get_sale_price();
+                                            if ( $regular > 0 && $sale < $regular ) {
+                                                $discount = round( ( ( $regular - $sale ) / $regular ) * 100 );
+                                                echo '<p class="red-tag">' . esc_html( $discount ) . '% off</p>';
+                                            }
+                                        }
+                                        ?>
+                                    </div>
+                                    <p class="mb-24"><?php echo wp_kses_post( $product->get_short_description() ); ?></p>
+                                    <hr class="dash-line mb-16">
+                                    <div class="action-block mb-16">
+                                        <?php woocommerce_quantity_input(); ?>
+                                        <?php woocommerce_template_single_add_to_cart(); ?>
+                                        <a href="javascript:;" class="icon wishlist-icon"><i class="fa-light fa-heart"></i></a>
+                                    </div>
+                                    <hr class="dash-line mb-24">
+                                    <?php if ( wc_product_sku_enabled() && $product->get_sku() ) : ?>
+                                        <div class="mb-16">
+                                            <span class="bold-text accent-dark me-1"><?php esc_html_e( 'SKU:', 'twentytwenty-child' ); ?></span><span><?php echo esc_html( $product->get_sku() ); ?></span>
+                                        </div>
+                                    <?php endif; ?>
+                                    <div class="tags mb-24">
+                                        <span class="bold-text accent-dark me-1"><?php esc_html_e( 'Tags:', 'twentytwenty-child' ); ?></span>
+                                        <?php echo wc_get_product_tag_list( $product->get_id(), ', ' ); ?>
+                                    </div>
+                                    <hr class="dash-line mb-16">
+                                    <div class="d-flex justify-content-between align-items-center gap-2 mb-16">
+                                        <span class="bold-text accent-dark"><?php esc_html_e( 'Share:', 'twentytwenty-child' ); ?></span>
+                                        <ul class="unstyled social-icons">
+                                            <li><a href="#"><i class="fa-brands fa-facebook-f"></i></a></li>
+                                            <li><a href="#"><i class="fa-brands fa-x-twitter"></i></a></li>
+                                            <li><a href="#"><i class="fa-brands fa-pinterest"></i></a></li>
+                                        </ul>
+                                    </div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- integrate Bloom product detail style into WooCommerce single product template
- enqueue Bloom JavaScript assets

## Testing
- `php -l wp-content/themes/twentytwenty-child/woocommerce/content-single-product.php`
- `php -l wp-content/themes/twentytwenty-child/functions.php`
- `npm test` *(fails: package.json missing)*
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68493ac8ef90832a9719cf0b15cfd2a2